### PR TITLE
Adds note to the README to indicate that this repository has been archived

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,9 @@
 = trino-opa-authorizer
 
+IMPORTANT: This repository has been archived and is not being maintained any more.
+Development of this authorizer has been moved into the Trino project itself:
+https://github.com/trinodb/trino/pull/19532
+
 == Usage
 
 


### PR DESCRIPTION
Also link to the PR upstream to indicate where the code can be found now.
As it has not been merged yet, the PR is the best thing to link to I think as it shows where the code will reside in the trino repo.